### PR TITLE
Add Tailwind Dynamic Class Workaround

### DIFF
--- a/src/lib/components/sponsors/sponsorrow.svelte
+++ b/src/lib/components/sponsors/sponsorrow.svelte
@@ -1,11 +1,18 @@
 <script lang="ts">
   export let sponsorCount: number;
 
-  function getClasses(sponsorCount: number) {
-    return `logo-cloud grid-cols-1 lg:!grid-cols-${sponsorCount} gap-1`;
-  }
+  // Tailwind workaround for dynamic classes
+  const _possibleClasses: Array<string> = [
+    "lg:!grid-cols-1",
+    "lg:!grid-cols-2",
+    "lg:!grid-cols-3",
+    "lg:!grid-cols-4",
+    "lg:!grid-cols-5",
+  ]
+  // Use the _possibleClasses for linting
+  _possibleClasses;
 </script>
 
-<div class={getClasses(sponsorCount)}>
+<div class="logo-cloud grid-cols-1 lg:!grid-cols-{sponsorCount} gap-1">
   <slot />
 </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -20,7 +20,7 @@
   <div class="container mx-auto flex justify-center items-center">
     <img
       src="Wildfire Logo.png"
-      alt="Wildfire Logo"
+      alt="Wildfire Logo | Designed by Fan Zone Athletics https://www.fanzoneathletics.com/"
       class="w-3/5 md:w-1/3 mx-auto" />
   </div>
   <SponsorList>


### PR DESCRIPTION
The issue with the Sponsor Row classes were due to Tailwind not working with dynamic classes. As a workaround, I added a list of _possibleClasses to sponsorrow.svelte in an attempt to solve this problem.